### PR TITLE
libm8: Add delay between disable and enable commands when connecting to M8. 

### DIFF
--- a/src/libm8.cpp
+++ b/src/libm8.cpp
@@ -63,6 +63,7 @@ libm8::Error libm8::Client::connect(godot::String target_port_name)
 	print("port successfully opened!");
 
 	send_disable_display();
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	send_enable_display();
 	send_reset_display();
 	return OK;

--- a/src/libm8.hpp
+++ b/src/libm8.hpp
@@ -2,6 +2,8 @@
 
 #include "utilities.hpp"
 #include <cstdio>
+#include <chrono>
+#include <thread>
 #include <libserialport.h>
 
 // max amount of bytes that can be received in one read


### PR DESCRIPTION
Fixes display not showing for FW 6.0.0