### PR TITLE
build on MacOS M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ $ python -m pip install scons
 ```bash
 # with Homebrew
 $ brew install scons
+$ brew install python3
 $ brew install libserialport
 
 # with MacPorts
 $ macports install scons
+$ macports install python3
 $ macports install libserialport
 ```
 
@@ -165,8 +167,11 @@ $ macports install libserialport
 $ git clone https://github.com/octoocto/m8gd
 $ cd m8gd
 $ git submodule update --init
-$ python build.py
+$ export SCONS_CACHE=/tmp
+$ python3 build.py
 ```
+
+To build on Apple Silicon M-chips, add `--arch arm64` parameter to the build command.
 
 The `build.py` script will automatically download Godot and its export templates in order to export the project if it does not find a `godot` command. To force the script to run without downloading anything, run `python build.py --nodownload` instead.
 

--- a/build.py
+++ b/build.py
@@ -27,7 +27,7 @@ godot_url_root = (
         GODOT_VERSION, GODOT_BRANCH
     )
 )
-godot_zip_export_templates = "Godot_v{0}-{1}.tpz".format(GODOT_VERSION, GODOT_BRANCH)
+godot_zip_export_templates = "Godot_v{0}-{1}_export_templates.tpz".format(GODOT_VERSION, GODOT_BRANCH)
 godot_zip_win = "Godot_v{0}-{1}_win64.exe.zip".format(GODOT_VERSION, GODOT_BRANCH)
 godot_zip_linux = "Godot_v{0}-{1}_linux.x86_64.zip".format(GODOT_VERSION, GODOT_BRANCH)
 godot_zip_mac = "Godot_v{0}-{1}_macos.universal.zip".format(GODOT_VERSION, GODOT_BRANCH)
@@ -110,14 +110,14 @@ if args.dev:
 def get_export_templates_path() -> str:
     match platform.system():
         case "Windows":
-            return os.path.expandvars("%APPDATA%\\Godot\\export_templates\\4.3.stable")
+            return os.path.expandvars(f"%APPDATA%\\Godot\\export_templates\\{GODOT_VERSION}.stable")
         case "Linux":
             return os.path.expanduser(
-                "~/.local/share/godot/export_templates/4.3.stable"
+                f"~/.local/share/godot/export_templates/{GODOT_VERSION}.stable"
             )
-        case "MacOS":
+        case "MacOS" | "Darwin":
             return os.path.expanduser(
-                "~/Library/Application Support/Godot/export_templates/4.3.stable"
+                f"~/Library/Application Support/Godot/export_templates/{GODOT_VERSION}.stable"
             )
         case _:
             raise EnvironmentError()
@@ -245,6 +245,9 @@ def _println_err(text: str) -> None:
 # Build Script
 
 target_platform = platform.system().lower() if args.platform == "" else args.platform
+
+if target_platform == "darwin":
+    target_platform = "macos"
 
 if args.target == "template_debug":
     godot_target = "--export-debug"
@@ -387,7 +390,7 @@ def godot_export(godot_path: str, target: str, plat: str) -> bool:
 
 
 # export m8gd
-_println("Exporting Godot project...")
+_println(f"Exporting Godot project for {target_platform} platform...")
 
 if target_platform == "all":
     for plat in ["windows", "linux", "macos"]:


### PR DESCRIPTION
I was unable to build this project on Mac M1 with macOS 15 Sequoia and fresh Python 3.13.3 (homebrew) because of the thee things:
* Wrong local templates path (pointed to godot 4.3, when 4.4 was defined in the build.py)
* Wrong templates URL (now it has *_export_templates.tpz name)
* Another OS name detected in python3 ("Darwin" instead of "MacOS")

In this PR I've fixed these problems leaving backward compatibility with existing scripts.