### PR TITLE
Update README.md for Mac Building

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,13 @@ $ python -m pip install scons
 
 ```bash
 # with Homebrew
-$ brew install scons
-$ brew install python3
-$ brew install libserialport
+$ brew install scons python3 libserialport libtool
 
 # with MacPorts
 $ macports install scons
 $ macports install python3
 $ macports install libserialport
+$ macports install libtool
 ```
 
 ## Building From Source


### PR DESCRIPTION
The libtool requirement was missing in the MacOS instructions. Added that to both the Homebrew and MacPorts sections. Additionally, condensed the Homebrew install section to a one-liner, since that works great and is in keeping with the `pacman` instructions for Arch. I don't know how MacPorts works so I left that as multi-line.