### PR TITLE
refactor post-process shader code

### DIFF
--- a/project/main.gd
+++ b/project/main.gd
@@ -72,6 +72,8 @@ var _window_drag_initial_pos := Vector2.ZERO
 @onready var overlay_waveform: OverlayBase = %OverlayAudioWaveform
 @onready var overlay_display: OverlayBase = %OverlayDisplayPanel
 
+@onready var shaders: ShaderContainer = %ShaderContainer
+
 @onready var menu: MainMenu = %MainMenuPanel
 @onready var menu_scene: SceneConfigMenu = %SceneConfigMenu
 @onready var menu_camera: SceneCameraMenu = %SceneCameraMenu
@@ -137,18 +139,10 @@ func _process(delta: float) -> void:
 func _physics_process(delta: float) -> void:
 	update_audio_analyzer()
 
-	var modulate_color := m8_client.get_theme_colors()[0]
+	# var modulate_color := m8_client.get_theme_colors()[0]
 	# modulate_color.v = 1.0
-	%BGShader.material.set_shader_parameter("tint_color", modulate_color)
+	# %BGShader.material.set_shader_parameter("tint_color", modulate_color)
 
-	# do shader parameter responses to audio
-
-	%CRTShader3.material.set_shader_parameter(
-		"aberration", audio_level * visualizer_aberration_amount
-	)
-	%CRTShader3.material.set_shader_parameter(
-		"brightness", 1.0 + (audio_level * visualizer_brightness_amount)
-	)
 	# %BGShader.material.set_shader_parameter("brightness", 1.0 + (audio_level * visualizer_brightness_amount))
 
 	# fade out status message
@@ -412,22 +406,6 @@ func delete_profile(profile_name: String) -> void:
 	if profile_name == get_current_profile_name():
 		load_default_profile()
 	config.delete_profile(profile_name)
-
-
-func _get_propkey_overlay(overlay: Control, property: String) -> String:
-	return "overlay.%s.%s" % [overlay.name, property]
-
-
-func _get_propkey_camera(property: String) -> String:
-	return "camera.%s" % property
-
-
-func _get_propkey_filter(filter: ColorRect, property: String) -> String:
-	return "filter.%s.%s" % [filter.name, property]
-
-
-func _get_propkey_filter_shader(filter: ColorRect, property: String) -> String:
-	return "filter.%s.shader.%s" % [filter.name, property]
 
 
 ##

--- a/project/main.tscn
+++ b/project/main.tscn
@@ -1,18 +1,13 @@
-[gd_scene load_steps=45 format=3 uid="uid://b265ke8cr3dgr"]
+[gd_scene load_steps=31 format=3 uid="uid://b265ke8cr3dgr"]
 
 [ext_resource type="Script" uid="uid://d0olbd611iax7" path="res://main.gd" id="1_4g2n0"]
-[ext_resource type="Shader" uid="uid://ddeledy6hskpq" path="res://shaders/post_process.gdshader" id="1_tjung"]
-[ext_resource type="Shader" uid="uid://uqrhgh7cj8gu" path="res://shaders/crt.gdshader" id="2_2rjfu"]
-[ext_resource type="Shader" uid="uid://i526eiqcypjg" path="res://shaders/vhs.gdshader" id="2_34vyn"]
 [ext_resource type="PackedScene" uid="uid://263mog4cxgwr" path="res://overlays/overlay_audio_spectrum.tscn" id="2_tbmna"]
-[ext_resource type="Texture2D" uid="uid://7y0rs0v6d4nk" path="res://assets/noise.png" id="4_gv8ps"]
-[ext_resource type="Shader" uid="uid://ckswjnsuddnrt" path="res://shaders/vhs2.gdshader" id="4_ioov3"]
 [ext_resource type="PackedScene" uid="uid://bkmg6tijdna2y" path="res://overlays/overlay_display_panel.tscn" id="4_nrhlm"]
-[ext_resource type="Shader" uid="uid://6tp4l6soye54" path="res://shaders/vhs3.gdshader" id="4_tq17m"]
 [ext_resource type="PackedScene" uid="uid://dq6heks88e2ip" path="res://overlays/overlay_audio_waveform.tscn" id="5_p87tv"]
 [ext_resource type="Shader" uid="uid://okxo3d88kn1h" path="res://shaders/screen_blur.gdshader" id="7_5hn1q"]
 [ext_resource type="PackedScene" uid="uid://d13t756slc8b0" path="res://ui/menus/main_menu.tscn" id="7_k5oyo"]
 [ext_resource type="PackedScene" uid="uid://ca2jqh2tc7jix" path="res://overlays/overlay_keys.tscn" id="8_dnyct"]
+[ext_resource type="PackedScene" uid="uid://cbhidmd8p855r" path="res://ui/shader_container.tscn" id="8_yaehf"]
 [ext_resource type="PackedScene" uid="uid://dv8crbibtrpck" path="res://ui/menus/menu_scene_config.tscn" id="9_bisyb"]
 [ext_resource type="FontFile" uid="uid://c2qpt2alp4ic3" path="res://assets/FSEX302.ttf" id="13_82xsv"]
 [ext_resource type="Theme" uid="uid://c8lf57q2f23tp" path="res://ui/theme/menu_theme.tres" id="13_e5i6c"]
@@ -47,108 +42,6 @@ shader_parameter/noise_texture = SubResource("NoiseTexture2D_lsac7")
 shader_parameter/noise_strength = 0.0
 shader_parameter/noise_speed = 1.0
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_x0ssf"]
-shader = ExtResource("4_ioov3")
-shader_parameter/wiggle = 0.03
-shader_parameter/wiggle_speed = 25.0
-shader_parameter/smear = 0.2
-shader_parameter/blur_samples = 15
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_i0wc8"]
-shader = ExtResource("2_34vyn")
-shader_parameter/vhs_resolution = Vector2(960, 720)
-shader_parameter/samples = 2
-shader_parameter/crease_noise = 1.0
-shader_parameter/crease_opacity = 0.5
-shader_parameter/filter_intensity = 0.0
-shader_parameter/tape_crease_smear = 0.2
-shader_parameter/tape_crease_intensity = 0.0
-shader_parameter/tape_crease_jitter = 0.1
-shader_parameter/tape_crease_speed = 0.5
-shader_parameter/tape_crease_discoloration = 0.0
-shader_parameter/bottom_border_thickness = 6.0
-shader_parameter/bottom_border_jitter = 24.0
-shader_parameter/noise_intensity = 0.0
-shader_parameter/noise_texture = ExtResource("4_gv8ps")
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_j82o4"]
-shader = ExtResource("4_tq17m")
-shader_parameter/res = Vector2(960, 720)
-shader_parameter/mask_type = 0
-shader_parameter/bloom_type = 0
-shader_parameter/hardScan = -4.0
-shader_parameter/hardPix = -2.0
-shader_parameter/hardBloomScan = -2.0
-shader_parameter/hardBloomPix = -1.5
-shader_parameter/bloomAmount = 16.0
-shader_parameter/warp = Vector2(500, 500)
-shader_parameter/maskDark = 1.0
-shader_parameter/maskLight = 2.0
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_pe34f"]
-shader = ExtResource("1_tjung")
-shader_parameter/effect = -1.0
-shader_parameter/effect_scale = 1.0
-shader_parameter/crop = 1.0
-shader_parameter/warp_amount = -0.885
-shader_parameter/warp_aspect = 1.0
-shader_parameter/border_alpha = -1.145
-shader_parameter/ca_amount = 0.0
-shader_parameter/mirror_blur = 0.5
-shader_parameter/reflection_amount = 0.39
-shader_parameter/mirror_overlay = Color(1, 1, 1, 0.215686)
-shader_parameter/border_color = Color(0.06, 0.06, 0.06, 1)
-shader_parameter/border_shadow_range = 6.42
-shader_parameter/border_shadow_ramp = 0.485
-shader_parameter/vignette_ramp = 0.16
-shader_parameter/vignette_range = 1.045
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_udd8c"]
-shader = ExtResource("2_2rjfu")
-shader_parameter/overlay = false
-shader_parameter/scanlines_opacity = 0.0
-shader_parameter/scanlines_width = 0.25
-shader_parameter/grille_opacity = 0.0
-shader_parameter/resolution = Vector2(640, 480)
-shader_parameter/pixelate = false
-shader_parameter/roll = false
-shader_parameter/roll_speed = 8.0
-shader_parameter/roll_size = 15.0
-shader_parameter/roll_variation = 1.8
-shader_parameter/distort_intensity = 0.05
-shader_parameter/noise_opacity = 0.0
-shader_parameter/noise_speed = 5.0
-shader_parameter/static_noise_intensity = 0.0
-shader_parameter/aberration = 0.03
-shader_parameter/brightness = 1.0
-shader_parameter/discolor = false
-shader_parameter/warp_amount = 0.5
-shader_parameter/clip_warp = false
-shader_parameter/vignette_intensity = 0.4
-shader_parameter/vignette_opacity = 0.5
-shader_parameter/vignette_noise = 0.1
-
-[sub_resource type="Gradient" id="Gradient_2ccln"]
-
-[sub_resource type="FastNoiseLite" id="FastNoiseLite_np6uh"]
-frequency = 1.0
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_m6tfj"]
-width = 4096
-height = 4096
-noise = SubResource("FastNoiseLite_np6uh")
-color_ramp = SubResource("Gradient_2ccln")
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_aaaol"]
-shader = ExtResource("7_5hn1q")
-shader_parameter/blur_amount = 0.0
-shader_parameter/tint_color = Color(1, 1, 1, 1)
-shader_parameter/tint_amount = 0.0
-shader_parameter/brightness = 1.0
-shader_parameter/noise_texture = SubResource("NoiseTexture2D_m6tfj")
-shader_parameter/noise_strength = 0.015
-shader_parameter/noise_speed = 1.0
-
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_0a764"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xqpi0"]
@@ -167,7 +60,7 @@ anti_aliasing_size = 0.5
 [sub_resource type="LabelSettings" id="LabelSettings_getpj"]
 font = ExtResource("13_82xsv")
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ryguw"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_yaehf"]
 content_margin_left = 0.0
 content_margin_top = 0.0
 content_margin_right = 0.0
@@ -188,7 +81,7 @@ expand_margin_right = 1.0
 expand_margin_bottom = 1.0
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_d13ii"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_074og"]
 content_margin_left = 0.0
 content_margin_top = 0.0
 content_margin_right = 0.0
@@ -209,7 +102,7 @@ expand_margin_right = 1.0
 expand_margin_bottom = 1.0
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1u8w0"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_cegan"]
 content_margin_left = 0.0
 content_margin_top = 0.0
 content_margin_right = 0.0
@@ -230,7 +123,7 @@ expand_margin_right = 1.0
 expand_margin_bottom = 1.0
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0odxb"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_82xsv"]
 content_margin_left = 0.0
 content_margin_top = 0.0
 content_margin_right = 0.0
@@ -274,10 +167,12 @@ grow_vertical = 2
 theme = ExtResource("13_e5i6c")
 
 [node name="BackBufferCopy" type="BackBufferCopy" parent="CanvasLayer/UI"]
+visible = false
 copy_mode = 2
 
 [node name="BGShader" type="ColorRect" parent="CanvasLayer/UI"]
 unique_name_in_owner = true
+visible = false
 material = SubResource("ShaderMaterial_dw8ip")
 layout_mode = 1
 anchors_preset = 15
@@ -367,94 +262,13 @@ size_flags_vertical = 10
 position_offset = Vector2i(-30, -100)
 
 [node name="BackBufferCopy2" type="BackBufferCopy" parent="CanvasLayer/UI"]
+visible = false
 position = Vector2(-24, -160)
 copy_mode = 2
 
-[node name="VHSShader1" type="ColorRect" parent="CanvasLayer/UI"]
+[node name="ShaderContainer" parent="CanvasLayer/UI" instance=ExtResource("8_yaehf")]
 unique_name_in_owner = true
-visible = false
-material = SubResource("ShaderMaterial_x0ssf")
 layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="BackBufferCopy2" type="BackBufferCopy" parent="CanvasLayer/UI/VHSShader1"]
-copy_mode = 2
-
-[node name="VHSShader2" type="ColorRect" parent="CanvasLayer/UI"]
-unique_name_in_owner = true
-visible = false
-material = SubResource("ShaderMaterial_i0wc8")
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="BackBufferCopy" type="BackBufferCopy" parent="CanvasLayer/UI/VHSShader2"]
-copy_mode = 2
-
-[node name="CRTShader1" type="ColorRect" parent="CanvasLayer/UI"]
-unique_name_in_owner = true
-visible = false
-material = SubResource("ShaderMaterial_j82o4")
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="BackBufferCopy2" type="BackBufferCopy" parent="CanvasLayer/UI/CRTShader1"]
-copy_mode = 2
-
-[node name="CRTShader2" type="ColorRect" parent="CanvasLayer/UI"]
-unique_name_in_owner = true
-visible = false
-material = SubResource("ShaderMaterial_pe34f")
-custom_minimum_size = Vector2(1280, 960)
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="BackBufferCopy" type="BackBufferCopy" parent="CanvasLayer/UI/CRTShader2"]
-copy_mode = 2
-
-[node name="CRTShader3" type="ColorRect" parent="CanvasLayer/UI"]
-unique_name_in_owner = true
-visible = false
-material = SubResource("ShaderMaterial_udd8c")
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="BackBufferCopy" type="BackBufferCopy" parent="CanvasLayer/UI/CRTShader3"]
-copy_mode = 2
-
-[node name="NoiseShader" type="ColorRect" parent="CanvasLayer/UI"]
-unique_name_in_owner = true
-visible = false
-material = SubResource("ShaderMaterial_aaaol")
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="BackBufferCopy" type="BackBufferCopy" parent="CanvasLayer/UI/NoiseShader"]
-visible = false
-copy_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="CanvasLayer/UI"]
 visible = false
@@ -905,7 +719,7 @@ visible = false
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 8
-theme_override_styles/panel = SubResource("StyleBoxFlat_ryguw")
+theme_override_styles/panel = SubResource("StyleBoxFlat_yaehf")
 
 [node name="SceneConfigMenu" parent="CanvasLayer/ScalableContainer/MarginContainer/VBoxContainer" instance=ExtResource("9_bisyb")]
 unique_name_in_owner = true
@@ -913,7 +727,7 @@ visible = false
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 8
-theme_override_styles/panel = SubResource("StyleBoxFlat_d13ii")
+theme_override_styles/panel = SubResource("StyleBoxFlat_074og")
 
 [node name="MenuOverlay" parent="CanvasLayer/ScalableContainer/MarginContainer/VBoxContainer" instance=ExtResource("16_4bi6d")]
 unique_name_in_owner = true
@@ -921,7 +735,7 @@ visible = false
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 8
-theme_override_styles/panel = SubResource("StyleBoxFlat_1u8w0")
+theme_override_styles/panel = SubResource("StyleBoxFlat_cegan")
 
 [node name="MainMenuContainer" type="ScrollContainer" parent="CanvasLayer/ScalableContainer"]
 layout_mode = 2
@@ -942,7 +756,7 @@ z_index = 1
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
-theme_override_styles/panel = SubResource("StyleBoxFlat_0odxb")
+theme_override_styles/panel = SubResource("StyleBoxFlat_82xsv")
 
 [node name="M8GD" type="M8GD" parent="."]
 unique_name_in_owner = true

--- a/project/ui/menus/menu_colors.gd
+++ b/project/ui/menus/menu_colors.gd
@@ -84,7 +84,7 @@ func _on_menu_init() -> void:
 	Events.profile_loaded.connect(
 		func(_profile_name: String) -> void:
 			for setting: SettingColor in all_settings:
-				setting.reinit()
+				setting.reload()
 	)
 
 	Events.scene_loaded.connect(

--- a/project/ui/menus/menu_overlays.gd
+++ b/project/ui/menus/menu_overlays.gd
@@ -50,12 +50,12 @@ func _on_menu_init() -> void:
 
 	Events.profile_loaded.connect(
 		func(_profile_name: String) -> void:
-			s_scale.reinit()
-			s_apply_filters.reinit()
-			s_spectrum_enable.reinit()
-			s_waveform_enable.reinit()
-			s_display_enable.reinit()
-			s_keys_enable.reinit()
+			s_scale.reload()
+			s_apply_filters.reload()
+			s_spectrum_enable.reload()
+			s_waveform_enable.reload()
+			s_display_enable.reload()
+			s_keys_enable.reload()
 	)
 
 	button_spectrum_config.pressed.connect(

--- a/project/ui/menus/menu_scene.gd
+++ b/project/ui/menus/menu_scene.gd
@@ -91,10 +91,10 @@ func _init_menu_camera() -> void:
 			%Setting_MouseCamera.enabled = true
 			%Setting_HumanCamera.enabled = true
 
-			%Setting_MouseCamera.reinit()
-			%Setting_HumanCamera.reinit()
-			%Setting_HumanCameraStrength.reinit()
-			%Setting_HumanCameraFrequency.reinit()
+			%Setting_MouseCamera.reload()
+			%Setting_HumanCamera.reload()
+			%Setting_HumanCameraStrength.reload()
+			%Setting_HumanCameraFrequency.reload()
 	)
 
 
@@ -141,10 +141,10 @@ func _init_menu_model() -> void:
 			%Setting_ModelScreenEmission.enabled = enabled
 
 			if enabled:
-				%Setting_ModelType.reinit()
-				%Setting_ModelHighlightOpacity.reinit()
-				%Setting_ModelScreenFilter.reinit()
-				%Setting_ModelScreenEmission.reinit()
+				%Setting_ModelType.reload()
+				%Setting_ModelHighlightOpacity.reload()
+				%Setting_ModelScreenFilter.reload()
+				%Setting_ModelScreenEmission.reload()
 	)
 
 

--- a/project/ui/menus/menu_scene_camera.gd
+++ b/project/ui/menus/menu_scene_camera.gd
@@ -42,15 +42,15 @@ func _on_menu_init() -> void:
 
 ##
 ## Called when a scene has been loaded.
-## This will reinit setting values from the config.
+## This will reload setting values from the config.
 ##
 func on_scene_loaded() -> void:
 	var camera := main.get_scene_camera()
 	if camera:
-		s_position.reinit()
-		s_angle.reinit()
-		s_focus.reinit()
-		s_blur.reinit()
+		s_position.reload()
+		s_angle.reload()
+		s_focus.reload()
+		s_blur.reload()
 		camera.set_current_transform_as_base()
 		# print("camera menu: reinited")
 

--- a/project/ui/menus/menu_shaders.gd
+++ b/project/ui/menus/menu_shaders.gd
@@ -3,23 +3,23 @@ extends MenuBase
 
 
 func _on_menu_init() -> void:
+	var shaders: ShaderContainer = main.shaders
+
 	%Setting_ShaderVHS.setting_connect_profile(
 		"shader_vhs",
 		func(value: bool) -> void:
-			main.get_node("%VHSShader1").visible = value
-			main.get_node("%VHSShader2").visible = value
+			shaders.vhs_shader_1.visible = value
+			shaders.vhs_shader_2.visible = value
 	)
 	%Setting_ShaderCRT.setting_connect_profile(
 		"shader_crt",
 		func(value: bool) -> void:
-			main.get_node("%CRTShader1").visible = value and %Setting_ShaderCRTScanLines.value
-			main.get_node("%CRTShader2").visible = (
-				value and %Setting_ShaderCRTReverseCurvature.value
-			)
-			main.get_node("%CRTShader3").visible = value
+			shaders.crt_shader_1.visible = value and %Setting_ShaderCRTScanLines.value
+			shaders.crt_shader_2.visible = (value and %Setting_ShaderCRTReverseCurvature.value)
+			shaders.crt_shader_3.visible = value
 	)
 	%Setting_ShaderNoise.setting_connect_profile(
-		"shader_noise", func(value: bool) -> void: main.get_node("%NoiseShader").visible = value
+		"shader_noise", func(value: bool) -> void: shaders.noise_shader.visible = value
 	)
 
 	%Setting_ShaderVHSSmear.init_config_shader("%VHSShader1", "smear")
@@ -29,13 +29,11 @@ func _on_menu_init() -> void:
 
 	%Setting_ShaderCRTScanLines.setting_connect_profile(
 		"shader_crt_scan_lines",
-		func(value: bool) -> void:
-			main.get_node("%CRTShader1").visible = value and %Setting_ShaderCRT.value
+		func(value: bool) -> void: shaders.crt_shader_1.visible = value and %Setting_ShaderCRT.value
 	)
 	%Setting_ShaderCRTReverseCurvature.setting_connect_profile(
 		"shader_crt_reverse_curvature",
-		func(value: bool) -> void:
-			main.get_node("%CRTShader2").visible = value and %Setting_ShaderCRT.value
+		func(value: bool) -> void: shaders.crt_shader_2.visible = value and %Setting_ShaderCRT.value
 	)
 	%Setting_ShaderCRTCurvature.init_config_shader("%CRTShader3", "warp_amount")
 	%Setting_ShaderCRTVignette.init_config_shader("%CRTShader3", "vignette_opacity")
@@ -48,6 +46,7 @@ func _on_menu_init() -> void:
 	)
 
 	%Setting_ShaderNoiseStrength.init_config_shader("%NoiseShader", "noise_strength")
+	%Setting_ShaderNoiseStrength.enable_if(%Setting_ShaderNoise)
 
 	%Setting_ShaderVHSSmear.enable_if(%Setting_ShaderVHS)
 	%Setting_ShaderVHSWiggle.enable_if(%Setting_ShaderVHS)
@@ -63,18 +62,18 @@ func _on_menu_init() -> void:
 
 	Events.profile_loaded.connect(
 		func(_profile_name: String) -> void:
-			%Setting_ShaderVHS.reinit()
-			%Setting_ShaderVHSSmear.reinit()
-			%Setting_ShaderVHSWiggle.reinit()
-			%Setting_ShaderVHSNoise.reinit()
-			%Setting_ShaderVHSTape.reinit()
-			%Setting_ShaderCRT.reinit()
-			%Setting_ShaderCRTScanLines.reinit()
-			%Setting_ShaderCRTReverseCurvature.reinit()
-			%Setting_ShaderCRTCurvature.reinit()
-			%Setting_ShaderCRTVignette.reinit()
-			%Setting_ShaderCRTAudioB.reinit()
-			%Setting_ShaderCRTAudioCA.reinit()
-			%Setting_ShaderNoise.reinit()
-			%Setting_ShaderNoiseStrength.reinit()
+			%Setting_ShaderVHS.reload()
+			%Setting_ShaderVHSSmear.reload()
+			%Setting_ShaderVHSWiggle.reload()
+			%Setting_ShaderVHSNoise.reload()
+			%Setting_ShaderVHSTape.reload()
+			%Setting_ShaderCRT.reload()
+			%Setting_ShaderCRTScanLines.reload()
+			%Setting_ShaderCRTReverseCurvature.reload()
+			%Setting_ShaderCRTCurvature.reload()
+			%Setting_ShaderCRTVignette.reload()
+			%Setting_ShaderCRTAudioB.reload()
+			%Setting_ShaderCRTAudioCA.reload()
+			%Setting_ShaderNoise.reload()
+			%Setting_ShaderNoiseStrength.reload()
 	)

--- a/project/ui/settings/setting_vec2.gd
+++ b/project/ui/settings/setting_vec2.gd
@@ -103,8 +103,8 @@ func _update_format() -> void:
 ## set the property in the current scene's camera.
 ##
 func setting_connect_camera_2(property_x: String, property_y: String) -> void:
-	var config_property_x := main._get_propkey_camera(property_x)
-	var config_property_y := main._get_propkey_camera(property_y)
+	var config_property_x := _get_propkey_camera(property_x)
+	var config_property_y := _get_propkey_camera(property_y)
 	setting_connect(
 		func() -> Variant:
 			var camera := main.get_scene_camera()

--- a/project/ui/shader_container.gd
+++ b/project/ui/shader_container.gd
@@ -1,0 +1,74 @@
+@tool
+class_name ShaderContainer
+extends Container
+
+@onready var vhs_shader_1: ColorRect = %VHSShader1
+@onready var vhs_shader_2: ColorRect = %VHSShader2
+@onready var crt_shader_1: ColorRect = %CRTShader1
+@onready var crt_shader_2: ColorRect = %CRTShader2
+@onready var crt_shader_3: ColorRect = %CRTShader3
+@onready var noise_shader: ColorRect = %NoiseShader
+
+var main: Main
+
+
+func _ready() -> void:
+	if not Main.is_ready():
+		await Events.initialized
+
+	main = Main.instance
+
+
+func _physics_process(_delta: float) -> void:
+	if not main:
+		return
+
+	crt_shader_3.material.set_shader_parameter(
+		"aberration", main.audio_level * main.visualizer_aberration_amount
+	)
+	crt_shader_3.material.set_shader_parameter(
+		"brightness", 1.0 + (main.audio_level * main.visualizer_brightness_amount)
+	)
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_SORT_CHILDREN:
+		_on_update()
+
+
+func has_shader_parameter(shader_mat: ShaderMaterial, shader_parameter: String) -> bool:
+	for d: Dictionary in shader_mat.shader.get_shader_uniform_list():
+		if d.name == shader_parameter:
+			return true
+	return false
+
+
+func get_shader_parameter(shader_node_path: NodePath, shader_parameter: String) -> Variant:
+	var shader_mat: ShaderMaterial = get_node(shader_node_path).material
+	assert(
+		has_shader_parameter(shader_mat, shader_parameter),
+		(
+			"shader parameter does not exist in %s: %s"
+			% [shader_mat.shader.resource_path, shader_parameter]
+		)
+	)
+	return shader_mat.get_shader_parameter(shader_parameter)
+
+
+func set_shader_parameter(
+	shader_node_path: NodePath, shader_parameter: String, value: Variant
+) -> void:
+	var shader_mat: ShaderMaterial = get_node(shader_node_path).material
+	assert(
+		has_shader_parameter(shader_mat, shader_parameter),
+		(
+			"shader parameter does not exist in %s: %s"
+			% [shader_mat.shader.resource_path, shader_parameter]
+		)
+	)
+	shader_mat.set_shader_parameter(shader_parameter, value)
+
+
+func _on_update() -> void:
+	for c in get_children():
+		fit_child_in_rect(c, Rect2(Vector2.ZERO, size))

--- a/project/ui/shader_container.gd.uid
+++ b/project/ui/shader_container.gd.uid
@@ -1,0 +1,1 @@
+uid://dieothx7vqs3u

--- a/project/ui/shader_container.tscn
+++ b/project/ui/shader_container.tscn
@@ -1,0 +1,170 @@
+[gd_scene load_steps=19 format=3 uid="uid://cbhidmd8p855r"]
+
+[ext_resource type="Script" uid="uid://dieothx7vqs3u" path="res://ui/shader_container.gd" id="1_wkkq6"]
+[ext_resource type="Script" uid="uid://dlk4lcv1bs1f4" path="res://ui/shader_rect.gd" id="2_elf6w"]
+[ext_resource type="Shader" uid="uid://ckswjnsuddnrt" path="res://shaders/vhs2.gdshader" id="2_u8vuk"]
+[ext_resource type="Shader" uid="uid://i526eiqcypjg" path="res://shaders/vhs.gdshader" id="3_elf6w"]
+[ext_resource type="Texture2D" uid="uid://7y0rs0v6d4nk" path="res://assets/noise.png" id="4_orrwf"]
+[ext_resource type="Shader" uid="uid://6tp4l6soye54" path="res://shaders/vhs3.gdshader" id="5_7ebwg"]
+[ext_resource type="Shader" uid="uid://ddeledy6hskpq" path="res://shaders/post_process.gdshader" id="6_gl8iy"]
+[ext_resource type="Shader" uid="uid://uqrhgh7cj8gu" path="res://shaders/crt.gdshader" id="7_ukupx"]
+[ext_resource type="Shader" uid="uid://okxo3d88kn1h" path="res://shaders/screen_blur.gdshader" id="8_jqubv"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_wkkq6"]
+shader = ExtResource("2_u8vuk")
+shader_parameter/wiggle = 0.03
+shader_parameter/wiggle_speed = 25.0
+shader_parameter/smear = 1.0
+shader_parameter/blur_samples = 15
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_0idq4"]
+shader = ExtResource("3_elf6w")
+shader_parameter/vhs_resolution = Vector2(960, 720)
+shader_parameter/samples = 2
+shader_parameter/crease_noise = 1.0
+shader_parameter/crease_opacity = 0.5
+shader_parameter/filter_intensity = 0.0
+shader_parameter/tape_crease_smear = 0.2
+shader_parameter/tape_crease_intensity = 0.0
+shader_parameter/tape_crease_jitter = 0.1
+shader_parameter/tape_crease_speed = 0.5
+shader_parameter/tape_crease_discoloration = 0.0
+shader_parameter/bottom_border_thickness = 6.0
+shader_parameter/bottom_border_jitter = 24.0
+shader_parameter/noise_intensity = 0.0
+shader_parameter/noise_texture = ExtResource("4_orrwf")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_5du23"]
+shader = ExtResource("5_7ebwg")
+shader_parameter/res = Vector2(960, 720)
+shader_parameter/mask_type = 0
+shader_parameter/bloom_type = 0
+shader_parameter/hardScan = -4.0
+shader_parameter/hardPix = -2.0
+shader_parameter/hardBloomScan = -2.0
+shader_parameter/hardBloomPix = -1.5
+shader_parameter/bloomAmount = 16.0
+shader_parameter/warp = Vector2(500, 500)
+shader_parameter/maskDark = 1.0
+shader_parameter/maskLight = 2.0
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_gfqpc"]
+shader = ExtResource("6_gl8iy")
+shader_parameter/effect = -1.0
+shader_parameter/effect_scale = 1.0
+shader_parameter/crop = 1.0
+shader_parameter/warp_amount = -0.885
+shader_parameter/warp_aspect = 1.0
+shader_parameter/border_alpha = -1.145
+shader_parameter/ca_amount = 0.0
+shader_parameter/mirror_blur = 0.5
+shader_parameter/reflection_amount = 0.39
+shader_parameter/mirror_overlay = Color(1, 1, 1, 0.215686)
+shader_parameter/border_color = Color(0.06, 0.06, 0.06, 1)
+shader_parameter/border_shadow_range = 6.42
+shader_parameter/border_shadow_ramp = 0.485
+shader_parameter/vignette_ramp = 0.16
+shader_parameter/vignette_range = 1.045
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_4xdhc"]
+shader = ExtResource("7_ukupx")
+shader_parameter/overlay = false
+shader_parameter/scanlines_opacity = 0.0
+shader_parameter/scanlines_width = 0.25
+shader_parameter/grille_opacity = 0.0
+shader_parameter/resolution = Vector2(640, 480)
+shader_parameter/pixelate = false
+shader_parameter/roll = false
+shader_parameter/roll_speed = 8.0
+shader_parameter/roll_size = 15.0
+shader_parameter/roll_variation = 1.8
+shader_parameter/distort_intensity = 0.05
+shader_parameter/noise_opacity = 0.0
+shader_parameter/noise_speed = 5.0
+shader_parameter/static_noise_intensity = 0.0
+shader_parameter/aberration = 0.03
+shader_parameter/brightness = 1.0
+shader_parameter/discolor = false
+shader_parameter/warp_amount = 0.5
+shader_parameter/clip_warp = false
+shader_parameter/vignette_intensity = 0.4
+shader_parameter/vignette_opacity = 0.5
+shader_parameter/vignette_noise = 0.1
+
+[sub_resource type="Gradient" id="Gradient_2pcn5"]
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_cy2mg"]
+frequency = 1.0
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_m6tfj"]
+width = 4096
+height = 4096
+noise = SubResource("FastNoiseLite_cy2mg")
+color_ramp = SubResource("Gradient_2pcn5")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_w57ct"]
+shader = ExtResource("8_jqubv")
+shader_parameter/blur_amount = 0.0
+shader_parameter/tint_color = Color(1, 1, 1, 1)
+shader_parameter/tint_amount = 0.0
+shader_parameter/brightness = 1.0
+shader_parameter/noise_texture = SubResource("NoiseTexture2D_m6tfj")
+shader_parameter/noise_strength = 0.015
+shader_parameter/noise_speed = 1.0
+
+[node name="ShaderContainer" type="Container"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_wkkq6")
+
+[node name="VHSShader1" type="ColorRect" parent="."]
+unique_name_in_owner = true
+visible = false
+material = SubResource("ShaderMaterial_wkkq6")
+layout_mode = 2
+script = ExtResource("2_elf6w")
+shader_material = SubResource("ShaderMaterial_wkkq6")
+
+[node name="VHSShader2" type="ColorRect" parent="."]
+unique_name_in_owner = true
+visible = false
+material = SubResource("ShaderMaterial_0idq4")
+layout_mode = 2
+script = ExtResource("2_elf6w")
+shader_material = SubResource("ShaderMaterial_0idq4")
+
+[node name="CRTShader1" type="ColorRect" parent="."]
+unique_name_in_owner = true
+visible = false
+material = SubResource("ShaderMaterial_5du23")
+layout_mode = 2
+script = ExtResource("2_elf6w")
+shader_material = SubResource("ShaderMaterial_5du23")
+
+[node name="CRTShader2" type="ColorRect" parent="."]
+unique_name_in_owner = true
+visible = false
+material = SubResource("ShaderMaterial_gfqpc")
+custom_minimum_size = Vector2(1280, 960)
+layout_mode = 2
+script = ExtResource("2_elf6w")
+shader_material = SubResource("ShaderMaterial_gfqpc")
+
+[node name="CRTShader3" type="ColorRect" parent="."]
+unique_name_in_owner = true
+visible = false
+material = SubResource("ShaderMaterial_4xdhc")
+layout_mode = 2
+script = ExtResource("2_elf6w")
+shader_material = SubResource("ShaderMaterial_4xdhc")
+
+[node name="NoiseShader" type="ColorRect" parent="."]
+unique_name_in_owner = true
+visible = false
+material = SubResource("ShaderMaterial_w57ct")
+layout_mode = 2
+script = ExtResource("2_elf6w")
+shader_material = SubResource("ShaderMaterial_w57ct")

--- a/project/ui/shader_rect.gd
+++ b/project/ui/shader_rect.gd
@@ -1,0 +1,19 @@
+@tool
+class_name ShaderRect
+extends ColorRect
+
+@export var shader_material: ShaderMaterial
+
+
+func _ready() -> void:
+	if shader_material:
+		material = shader_material
+	else:
+		material = null
+
+	var back_buffer_copy := BackBufferCopy.new()
+	add_child(back_buffer_copy)
+	back_buffer_copy.copy_mode = BackBufferCopy.COPY_MODE_VIEWPORT
+	back_buffer_copy.set_owner(self)
+
+	set_anchors_and_offsets_preset(PRESET_FULL_RECT)

--- a/project/ui/shader_rect.gd.uid
+++ b/project/ui/shader_rect.gd.uid
@@ -1,0 +1,1 @@
+uid://dlk4lcv1bs1f4


### PR DESCRIPTION
- moves screen shader nodes out of `main.tscn` into their own scene `shader_container.tscn`
- create ShaderRect class to automate the ColorRect/BackBufferCopy setup for making screen-space shaders
- create ShaderContainer class to consolidate some shader-related functions that used to be in `main.gd`
- some settings-related code moved around/renamed in the process