### PR TITLE
various windows-related fixes

### DIFF
--- a/godot/device_manager.gd
+++ b/godot/device_manager.gd
@@ -119,6 +119,12 @@ func list_audio_devices(_show_all: bool = false) -> Array[String]:
 ## Connect to and monitor an audio input device with name [device].
 ## If [device] is empty, automatically connect to a valid M8 audio input device.
 func connect_audio_device(device: String = "", force: bool = false) -> void:
+	match audio_handler:
+		AudioHandler.SDL:
+			main.m8c.audio_set_backend("sdl")
+		AudioHandler.CPAL:
+			main.m8c.audio_set_backend("cpal")
+
 	if device == "":
 		if len(list_audio_devices()) > 0:
 			device = list_audio_devices()[0]
@@ -141,29 +147,15 @@ func connect_audio_device(device: String = "", force: bool = false) -> void:
 
 	disconnect_audio_device()
 
-	print("audio: initializing audio using handler: %s" % AudioHandler.keys()[audio_handler])
+	print("audio: starting audio using handler: %s" % AudioHandler.keys()[audio_handler])
 
-	match audio_handler:
-		AudioHandler.SDL:
-			print("audio: initializing SDL audio")
-			main.m8c.audio_set_backend("sdl")
-			if not main.m8c.audio_start(device, ""):
-				print("audio: failed to connect to device %s" % device)
-				main.menu.menu_devices.set_status_audiodevice(
-					"Not connected: failed to connect to: %s" % device,
-				)
-				is_audio_connecting = false
-				return
-		AudioHandler.CPAL:
-			print("audio: initializing CPAL audio")
-			main.m8c.audio_set_backend("cpal")
-			if not main.m8c.audio_start(device, ""):
-				print("audio: failed to connect to device %s" % device)
-				main.menu.menu_devices.set_status_audiodevice(
-					"Not connected: failed to connect to: %s" % device,
-				)
-				is_audio_connecting = false
-				return
+	if not main.m8c.audio_start(device, ""):
+		print("audio: failed to connect to device %s" % device)
+		main.menu.menu_devices.set_status_audiodevice(
+			"Not connected: failed to connect to: %s" % device,
+		)
+		is_audio_connecting = false
+		return
 
 	current_audio_device = device
 	last_audio_device = device
@@ -217,16 +209,9 @@ func is_audio_device_connected() -> bool:
 
 
 func audio_set_handler(handler: AudioHandler) -> void:
-	if handler == audio_handler:
+	if handler == self.audio_handler:
 		return
-
-	audio_handler = handler
-	match audio_handler:
-		AudioHandler.SDL:
-			main.m8c.audio_set_backend("sdl")
-		AudioHandler.CPAL:
-			main.m8c.audio_set_backend("cpal")
-
+	self.audio_handler = handler
 	print("audio: set audio handler to %s" % AudioHandler.keys()[audio_handler])
 
 	reset_audio_device()

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,6 +50,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "audio-codec-algorithms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1254ebf6529f3763c491acfb5ab6e960809e3c75a38584cc664f8c5667fb7107"
+
+[[package]]
+name = "audioadapter"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1292ef9edf681b7426ed089004b021a42896492f58bd0c909ad44e5faec9ac4"
+
+[[package]]
+name = "audioadapter-buffers"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46289a81a3bfa26d0f8b2415f8ca9decde9a66308a150568af5c102381b3c8ce"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5258faecf4edbe35ec483bda9b1f7438e6b391891819269c6b5461aeaa0e8d7d"
+dependencies = [
+ "audio-codec-algorithms",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +615,7 @@ dependencies = [
  "enum-map",
  "godot",
  "ringbuf",
+ "rubato",
  "sdl3",
  "sdl3-sys",
  "serialport",
@@ -799,6 +833,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1027,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1060,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
 ]
 
 [[package]]
@@ -1057,6 +1118,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a2d2f3481209a6b42eec2fbb49063fb4e8d35b57023401495d4fe0f85c817f0"
 
 [[package]]
+name = "rubato"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cb1ffaf8738df50aab642a7f6465df81c6ba9e2818268053487165298114be"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1146,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -1292,6 +1383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1530,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "unescaper"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1587,17 @@ name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "walkdir"
@@ -1553,6 +1671,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,7 @@ spectrum-analyzer = "=1.7.0"
 thiserror = "=2.0.17"
 
 godot = { version = "=0.5.4", features = ["register-docs"], optional = true }
+rubato = "5.0.0"
 
 [dependencies.sdl3-sys]
 version = "0.6.0"

--- a/rust/src/audio/cpal.rs
+++ b/rust/src/audio/cpal.rs
@@ -6,6 +6,8 @@ use enum_map::EnumMap;
 use m8::audio;
 use m8::{Error, SpectrumAnalyzer};
 use ringbuf::traits::{Consumer, Producer, Split};
+use rubato::audioadapter_buffers::direct::InterleavedSlice;
+use rubato::{self, Resampler};
 use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 
@@ -25,7 +27,7 @@ pub struct CpalAudioBackend {
     volume: Arc<Mutex<f32>>,
     volume_peaks: Arc<Mutex<[f32; 2]>>,
 
-    spectrum_analyzer_enabled: bool,
+    spectrum_analyzer_enabled: Arc<Mutex<bool>>,
     spectrum: Arc<Mutex<SpectrumAnalyzer>>,
 }
 
@@ -43,7 +45,7 @@ impl CpalAudioBackend {
             volume: Arc::new(Mutex::new(1.0)),
             volume_peaks: Arc::new(Mutex::new([0.0; 2])),
 
-            spectrum_analyzer_enabled: true,
+            spectrum_analyzer_enabled: Arc::new(Mutex::new(true)),
             spectrum: Arc::new(Mutex::new(SpectrumAnalyzer::new(SAMPLE_RATE as u32))),
         })
     }
@@ -84,7 +86,7 @@ impl super::AudioBackend for CpalAudioBackend {
 
         if input_devices.is_empty() {
             return Err(Error::AudioError(
-                "CPAL: No valid input devices found".to_string(),
+                "cpal-audio: No valid input devices found".to_string(),
             ));
         }
 
@@ -107,10 +109,44 @@ impl super::AudioBackend for CpalAudioBackend {
             }
         }
 
+        if self.input_device.is_none() {
+            return Err(Error::AudioError(
+                "cpal-audio: Unable to open any input devices".to_string(),
+            ));
+        }
+
+        let input_buffer_size = self.input_device.as_ref().unwrap().stream.buffer_size()?;
+        let input_sample_rate = self.input_device.as_ref().unwrap().config.sample_rate;
+
+        let output_buffer_size = match config_out.buffer_size {
+            cpal::BufferSize::Fixed(size) => size,
+            cpal::BufferSize::Default => panic!("buffer size is not fixed"),
+        };
+        let output_sample_rate = config_out.sample_rate;
+
+        println!("cpal-audio: input buffer size = {input_buffer_size}");
+        println!("cpal-audio: input sample rate = {input_sample_rate}");
+        println!("cpal-audio: output buffer size = {output_buffer_size}");
+        println!("cpal-audio: output sample rate = {output_sample_rate}");
+
+        let resampler = rubato::Fft::<f32>::new(
+            input_sample_rate as usize,
+            output_sample_rate as usize,
+            input_buffer_size as usize,
+            2,
+            rubato::FixedSync::Both,
+        )
+        .expect("failed to create resampler");
+
         self.output_device = Some(AudioStream::open_output(
             output_device,
             config_out,
-            self.on_output_data_requested(data_cons),
+            self.on_output_data_requested(
+                data_cons,
+                resampler,
+                input_buffer_size as usize,
+                output_buffer_size as usize,
+            ),
         )?);
 
         Ok(())
@@ -206,12 +242,15 @@ impl super::AudioBackend for CpalAudioBackend {
     }
 
     fn set_spectrum_analyzer_enabled(&mut self, enabled: bool) -> Result<(), Error> {
-        self.spectrum_analyzer_enabled = enabled;
+        if let Ok(spectrum_analyzer_enabled) = self.spectrum_analyzer_enabled.lock().as_deref_mut()
+        {
+            *spectrum_analyzer_enabled = enabled;
+        }
         Ok(())
     }
 
     fn is_spectrum_analyzer_enabled(&mut self) -> Result<bool, Error> {
-        Ok(self.spectrum_analyzer_enabled)
+        Ok(*self.spectrum_analyzer_enabled.lock().as_deref().unwrap())
     }
 
     fn input_spec(&self) -> Result<audio::AudioSpec, Error> {
@@ -303,10 +342,17 @@ impl CpalAudioBackend {
     fn on_output_data_requested(
         &self,
         mut data_cons: ringbuf::HeapCons<f32>,
+        mut resampler: rubato::Fft<f32>,
+        buffer_size_in: usize,
+        buffer_size_out: usize,
     ) -> impl FnMut(&mut [f32], &OutputCallbackInfo) + Send + 'static {
         let volume = self.volume.clone();
         let volume_peaks = self.volume_peaks.clone();
         let spectrum = self.spectrum.clone();
+        let spectrum_enabled = self.spectrum_analyzer_enabled.clone();
+
+        let mut buffer_in = vec![0.0; buffer_size_in * 2];
+        let mut buffer_out = vec![0.0; buffer_size_out * 2];
 
         move |data, _| {
             let Ok(volume) = volume.lock() else {
@@ -315,25 +361,49 @@ impl CpalAudioBackend {
             let Ok(peaks) = &mut volume_peaks.lock() else {
                 return;
             };
+            let Ok(spectrum_enabled) = spectrum_enabled.lock() else {
+                return;
+            };
+
             peaks[0] = 0.0;
             peaks[1] = 0.0;
+
+            data_cons.pop_slice(&mut buffer_in);
+
+            let adapter_in = match InterleavedSlice::new(&buffer_in, 2, buffer_size_in) {
+                Ok(adapter_in) => adapter_in,
+                Err(e) => {
+                    println!("size error when creating adapter_in:\n{e}");
+                    return;
+                }
+            };
+            let mut adapter_out =
+                match InterleavedSlice::new_mut(&mut buffer_out, 2, buffer_size_out) {
+                    Ok(adapter_out) => adapter_out,
+                    Err(e) => {
+                        println!("size error when creating adapter_out:\n{e}");
+                        return;
+                    }
+                };
+
+            if let Err(e) = resampler.process_into_buffer(&adapter_in, &mut adapter_out, None) {
+                println!("error when resampling:\n{e}");
+                return;
+            }
 
             // println!("CPAL: Output callback with {} samples", data.len());
 
             for (i, sample) in data.iter_mut().enumerate() {
-                *sample = match data_cons.try_pop() {
-                    Some(s) => {
-                        if s.abs() > peaks[i % 2] {
-                            peaks[i % 2] = s.abs();
-                        }
-                        s * *volume
-                    }
-                    None => 0.0,
-                };
+                let value = buffer_out[i];
+                if value.abs() > peaks[i % 2] {
+                    peaks[i % 2] = value.abs();
+                }
+                *sample = value * *volume;
             }
 
-            if let Ok(mut spectrum) = spectrum.lock() {
-                spectrum.update_fft(data);
+            if *spectrum_enabled && let Ok(mut spectrum) = spectrum.lock() {
+                let len_pow2 = data.len().checked_ilog2().map(|exp| 1 << exp).unwrap_or(0);
+                spectrum.update_fft(&data[..len_pow2]);
             }
         }
     }
@@ -381,7 +451,7 @@ fn find_input_devices(
     name: &Option<String>,
     channels: u16,
 ) -> Result<Vec<(cpal::Device, cpal::StreamConfig)>, Error> {
-    println!("CPAL: Finding input devices with name: {name:?}");
+    println!("cpal-audio: Finding input devices with name: {name:?}");
     let devices = host
         .input_devices()?
         // filter to only devices with a valid name and description
@@ -402,17 +472,22 @@ fn find_input_devices(
         })
         // find a suitable config for each device
         .filter_map(|device| {
-            let config = find_input_stream_config(&device, channels).ok()?;
-            Some((device, config))
+            if let Some(config) = find_input_stream_config(&device, 44100, channels).ok() {
+                Some((device, config))
+            } else if let Some(config) = find_input_stream_config(&device, 48000, channels).ok() {
+                Some((device, config))
+            } else {
+                None
+            }
         })
         .collect::<Vec<(cpal::Device, cpal::StreamConfig)>>();
 
-    println!("CPAL: Found {} valid input devices", devices.len());
+    println!("cpal-audio: Found {} valid input devices", devices.len());
     Ok(devices)
 }
 
 fn find_output_device(host: &Host, name: &Option<String>) -> Result<Device, Error> {
-    println!("CPAL: Finding output device with name: {name:?}");
+    println!("cpal-audio: Finding output device with name: {name:?}");
     let device = match name {
         None => host.default_output_device(),
         Some(name) => host
@@ -421,25 +496,28 @@ fn find_output_device(host: &Host, name: &Option<String>) -> Result<Device, Erro
     };
     if let Some(device) = device {
         println!(
-            "CPAL: Found output device: {}",
+            "cpal-audio: Found output device: {}",
             device.description()?.name()
         );
         Ok(device)
     } else {
         Err(Error::AudioError(
-            "CPAL: No output device found".to_string(),
+            "cpal-audio: No output device found".to_string(),
         ))
     }
 }
 
-fn find_input_stream_config(device: &Device, channels: u16) -> Result<StreamConfig, Error> {
+fn find_input_stream_config(
+    device: &Device,
+    sample_rate: u32,
+    channels: u16,
+) -> Result<StreamConfig, Error> {
     let sample_format = cpal::SampleFormat::F32;
-    let sample_rate = SAMPLE_RATE as u32;
     let buffer_size = BUFFER_SIZE as u32;
     // let buffer_size = 1024u32;
 
     println!(
-        "Finding input stream config for device: {}, driver: {:?}, channels: {}",
+        "cpal-audio: Finding input stream config for device: {}, driver: {:?}, channels: {}",
         device.to_string(),
         device.description()?.driver(),
         channels
@@ -452,25 +530,34 @@ fn find_input_stream_config(device: &Device, channels: u16) -> Result<StreamConf
             config_range.try_with_sample_rate(sample_rate)
         })
         .find(|config| {
-            // println!(
-            //     "- config: {{ channels: {}, sample_format: {:?}, buffer_size: {:?} }}",
-            //     config.channels(),
-            //     config.sample_format(),
-            //     config.buffer_size()
-            // );
+            println!(
+                "- config: {{ channels: {}, sample_format: {:?}, buffer_size: {:?} }}",
+                config.channels(),
+                config.sample_format(),
+                config.buffer_size()
+            );
             config.channels() == channels
                 && config.sample_format() == sample_format
                 && match config.buffer_size() {
                     cpal::SupportedBufferSize::Unknown => false,
-                    cpal::SupportedBufferSize::Range { min, max } => {
-                        &buffer_size >= min && &buffer_size <= max
-                    }
+                    cpal::SupportedBufferSize::Range { .. } => true,
                 }
         })
         .ok_or(Error::AudioError(
             "Unable to find a valid input config".to_string(),
         ))?;
 
+    let buffer_size = match supported_config.buffer_size() {
+        cpal::SupportedBufferSize::Range { min, max } => {
+            if &buffer_size >= min && &buffer_size <= max {
+                buffer_size
+            } else {
+                println!("cpal-audio: using buffer size {min} instead of {buffer_size}");
+                *min
+            }
+        }
+        cpal::SupportedBufferSize::Unknown => buffer_size,
+    };
     let mut config = supported_config.config();
     config.buffer_size = cpal::BufferSize::Fixed(buffer_size);
     Ok(config)
@@ -483,7 +570,14 @@ fn find_output_stream_config(device: &Device) -> Result<StreamConfig, Error> {
     // let buffer_size = 1024u32;
     let channels = 2u16;
 
-    device
+    println!(
+        "cpal-audio: Finding output stream config for device: {}, driver: {:?}, channels: {}",
+        device.to_string(),
+        device.description()?.driver(),
+        channels
+    );
+
+    let supported_config = device
         .supported_output_configs()?
         .find(|config| {
             config.channels() == channels
@@ -491,14 +585,24 @@ fn find_output_stream_config(device: &Device) -> Result<StreamConfig, Error> {
                 && config.sample_format() == sample_format
                 && match config.buffer_size() {
                     cpal::SupportedBufferSize::Unknown => false,
-                    cpal::SupportedBufferSize::Range { min, max } => {
-                        &buffer_size >= min && &buffer_size <= max
-                    }
+                    cpal::SupportedBufferSize::Range { .. } => true,
                 }
         })
         .ok_or(Error::AudioError(
             "Unable to find a valid output config".to_string(),
         ))?;
+
+    let buffer_size = match supported_config.buffer_size() {
+        cpal::SupportedBufferSize::Range { min, max } => {
+            if &buffer_size >= min && &buffer_size <= max {
+                buffer_size
+            } else {
+                println!("cpal-audio: using buffer size {min} instead of {buffer_size}");
+                *min
+            }
+        }
+        cpal::SupportedBufferSize::Unknown => buffer_size,
+    };
 
     Ok(StreamConfig {
         sample_rate,
@@ -524,7 +628,7 @@ impl AudioStream {
         let id = device.id()?;
         let driver = desc.driver();
         println!(
-            "CPAL: Opening input stream for device: {name} \n\
+            "cpal-audio: Opening input stream for device: {name} \n\
              -     id: {id:?} \n\
              - driver: {driver:?} \n\
              - config: {config:?}",
@@ -553,7 +657,7 @@ impl AudioStream {
         let id = device.id()?;
         let driver = desc.driver();
         println!(
-            "CPAL: Opening output stream for device: {name} \n\
+            "cpal-audio: Opening output stream for device: {name} \n\
              -     id: {id:?} \n\
              - driver: {driver:?} \n\
              - config: {config:?}",

--- a/rust/src/audio/sdl.rs
+++ b/rust/src/audio/sdl.rs
@@ -159,145 +159,6 @@ pub struct SdlAudioBackend {
     // output_stream: Option<Arc<Mutex<AudioStreamOwner>>>,
 }
 
-impl super::AudioBackend for SdlAudioBackend {
-    fn start(
-        &mut self,
-        input_device: Option<String>,
-        output_device: Option<String>,
-    ) -> Result<(), Error> {
-        let input_device = self.input_device(input_device)?;
-        let output_device = self.output_device(output_device)?;
-
-        println!(
-            "Using input device: {}",
-            input_device.id().name().unwrap_or("Unknown".to_string())
-        );
-        println!(
-            "Using output device: {}",
-            output_device.id().name().unwrap_or("Unknown".to_string())
-        );
-
-        let output_stream = output_device.open_device_stream(Some(&Self::DESIRED_SPEC_OUT))?;
-        output_stream.resume()?;
-
-        let input_stream = input_device.open_recording_stream_with_callback(
-            &Self::DESIRED_SPEC_IN,
-            AudioInCallback::new(output_stream, self.volume),
-        )?;
-
-        input_stream.resume()?;
-
-        self.input_stream = Some(input_stream);
-        self.input_stream_spec = Some(Self::get_audio_spec(input_device.id())?);
-
-        // self.output_stream = Some(output_stream);
-
-        Ok(())
-    }
-
-    fn stop(&mut self) -> Result<(), Error> {
-        self.input_stream = None;
-        self.input_stream_spec = None;
-        Ok(())
-    }
-
-    fn is_running(&self) -> bool {
-        // Note that the input stream also owns the output stream
-        self.input_stream.is_some()
-    }
-
-    fn list_input_devices(&self) -> Result<Vec<String>, Error> {
-        let input_devices = self
-            .input_devices()?
-            .iter()
-            .filter_map(|device| device.name().ok())
-            .collect();
-        Ok(input_devices)
-    }
-
-    fn list_output_devices(&self) -> Result<Vec<String>, Error> {
-        let output_devices = self
-            .output_devices()?
-            .iter()
-            .filter_map(|device| device.name().ok())
-            .collect();
-        Ok(output_devices)
-    }
-
-    fn volume(&mut self) -> Result<f32, Error> {
-        Ok(self.callback_lock()?.volume)
-    }
-
-    fn set_volume(&mut self, volume: f32) -> Result<(), Error> {
-        self.volume = volume.clamp(0.0, 1.0);
-        println!("libm8: Setting volume to {}", self.volume);
-        Ok(self.callback_lock()?.volume = self.volume)
-    }
-
-    fn peaks_linear(&mut self) -> Result<[f32; 2], Error> {
-        Ok(self.callback_lock()?.peaks)
-    }
-
-    fn value_at_frequency(&mut self, frequency: f32) -> Result<f32, Error> {
-        if let Ok(callback) = self.callback_lock() {
-            if callback.spectrum_analyzer_enabled {
-                return Ok(callback.spectrum.value_at_frequency(frequency));
-            }
-        }
-        Ok(0.0)
-    }
-
-    fn is_spectrum_analyzer_enabled(&mut self) -> Result<bool, Error> {
-        Ok(self.callback_lock()?.spectrum_analyzer_enabled)
-    }
-
-    fn set_spectrum_analyzer_enabled(&mut self, enabled: bool) -> Result<(), Error> {
-        self.callback_lock()?.spectrum_analyzer_enabled = enabled;
-        Ok(())
-    }
-
-    fn input_spec(&self) -> Result<audio::AudioSpec, Error> {
-        let (spec, samples) = self
-            .input_stream_spec
-            .as_ref()
-            .ok_or(AudioError("No input stream".to_string()))?;
-        Ok(audio::AudioSpec {
-            host: self.driver_name(),
-            format: format_name(spec.format),
-            num_channels: spec.channels.unwrap_or(0) as usize,
-            sample_rate: spec.freq.unwrap_or(0) as usize,
-            buffer_size: samples.clone(),
-        })
-    }
-
-    fn track_buffer(&self, _track: m8::Track) -> Result<Vec<f32>, Error> {
-        Ok(vec![0.0; BUFFER_SIZE * 2])
-    }
-
-    fn set_multichannel_mode(&mut self, _enabled: bool) -> Result<(), Error> {
-        Err(AudioError(
-            "Multichannel mode is not supported in SDL3 backend.".to_string(),
-        ))
-    }
-}
-
-fn format_name(format: Option<sdl3::audio::AudioFormat>) -> String {
-    let Some(format) = format else {
-        return "UNKNOWN".to_string();
-    };
-    match format {
-        sdl3::audio::AudioFormat::U8 => "U8".to_string(),
-        sdl3::audio::AudioFormat::S8 => "S8".to_string(),
-        sdl3::audio::AudioFormat::S16LE => "S16LE".to_string(),
-        sdl3::audio::AudioFormat::S16BE => "S16BE".to_string(),
-        sdl3::audio::AudioFormat::S32LE => "S32LE".to_string(),
-        sdl3::audio::AudioFormat::S32BE => "S32BE".to_string(),
-        sdl3::audio::AudioFormat::F32LE => "F32LE".to_string(),
-        sdl3::audio::AudioFormat::F32BE => "F32BE".to_string(),
-        sdl3::audio::AudioFormat::UNKNOWN => "UNKNOWN".to_string(),
-    }
-}
-
 impl SdlAudioBackend {
     const DESIRED_SPEC_IN: SdlAudioSpec = SdlAudioSpec {
         freq: Some(SAMPLE_RATE as i32),
@@ -436,5 +297,146 @@ impl SdlAudioBackend {
                 )))
             }
         }
+    }
+}
+
+impl super::AudioBackend for SdlAudioBackend {
+    fn start(
+        &mut self,
+        input_device: Option<String>,
+        output_device: Option<String>,
+    ) -> Result<(), Error> {
+        let input_device = self.input_device(input_device)?;
+        let output_device = self.output_device(output_device)?;
+
+        println!(
+            "sdl-audio: using input device: {}",
+            input_device.id().name().unwrap_or("Unknown".to_string())
+        );
+        println!(
+            "sdl-audio: using output device: {}",
+            output_device.id().name().unwrap_or("Unknown".to_string())
+        );
+
+        println!("sdl-audio: opening output stream...");
+        let output_stream = output_device
+            .clone()
+            .open_device_stream(Some(&Self::DESIRED_SPEC_OUT))?;
+        output_stream.resume()?;
+        println!("sdl-audio: opening output stream done");
+
+        println!("sdl-audio: opening input stream...");
+        let cb = AudioInCallback::new(output_stream, self.volume);
+        let input_stream =
+            input_device.open_recording_stream_with_callback(&Self::DESIRED_SPEC_IN, cb)?;
+        input_stream.resume()?;
+        println!("sdl-audio: opening input stream done");
+
+        self.input_stream = Some(input_stream);
+        self.input_stream_spec = Some(Self::get_audio_spec(input_device.id())?);
+
+        // self.output_stream = Some(output_stream);
+
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<(), Error> {
+        self.input_stream = None;
+        self.input_stream_spec = None;
+        Ok(())
+    }
+
+    fn is_running(&self) -> bool {
+        // Note that the input stream also owns the output stream
+        self.input_stream.is_some()
+    }
+
+    fn list_input_devices(&self) -> Result<Vec<String>, Error> {
+        let input_devices = self
+            .input_devices()?
+            .iter()
+            .filter_map(|device| device.name().ok())
+            .collect();
+        Ok(input_devices)
+    }
+
+    fn list_output_devices(&self) -> Result<Vec<String>, Error> {
+        let output_devices = self
+            .output_devices()?
+            .iter()
+            .filter_map(|device| device.name().ok())
+            .collect();
+        Ok(output_devices)
+    }
+
+    fn volume(&mut self) -> Result<f32, Error> {
+        Ok(self.callback_lock()?.volume)
+    }
+
+    fn set_volume(&mut self, volume: f32) -> Result<(), Error> {
+        self.volume = volume.clamp(0.0, 1.0);
+        println!("libm8: Setting volume to {}", self.volume);
+        Ok(self.callback_lock()?.volume = self.volume)
+    }
+
+    fn peaks_linear(&mut self) -> Result<[f32; 2], Error> {
+        Ok(self.callback_lock()?.peaks)
+    }
+
+    fn value_at_frequency(&mut self, frequency: f32) -> Result<f32, Error> {
+        if let Ok(callback) = self.callback_lock() {
+            if callback.spectrum_analyzer_enabled {
+                return Ok(callback.spectrum.value_at_frequency(frequency));
+            }
+        }
+        Ok(0.0)
+    }
+
+    fn is_spectrum_analyzer_enabled(&mut self) -> Result<bool, Error> {
+        Ok(self.callback_lock()?.spectrum_analyzer_enabled)
+    }
+
+    fn set_spectrum_analyzer_enabled(&mut self, enabled: bool) -> Result<(), Error> {
+        self.callback_lock()?.spectrum_analyzer_enabled = enabled;
+        Ok(())
+    }
+
+    fn input_spec(&self) -> Result<audio::AudioSpec, Error> {
+        let (spec, samples) = self
+            .input_stream_spec
+            .as_ref()
+            .ok_or(AudioError("No input stream".to_string()))?;
+        Ok(audio::AudioSpec {
+            host: self.driver_name(),
+            format: format_name(spec.format),
+            num_channels: spec.channels.unwrap_or(0) as usize,
+            sample_rate: spec.freq.unwrap_or(0) as usize,
+            buffer_size: samples.clone(),
+        })
+    }
+
+    fn track_buffer(&self, _track: m8::Track) -> Result<Vec<f32>, Error> {
+        Ok(vec![0.0; BUFFER_SIZE * 2])
+    }
+
+    fn set_multichannel_mode(&mut self, _enabled: bool) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+fn format_name(format: Option<sdl3::audio::AudioFormat>) -> String {
+    let Some(format) = format else {
+        return "UNKNOWN".to_string();
+    };
+    match format {
+        sdl3::audio::AudioFormat::U8 => "U8".to_string(),
+        sdl3::audio::AudioFormat::S8 => "S8".to_string(),
+        sdl3::audio::AudioFormat::S16LE => "S16LE".to_string(),
+        sdl3::audio::AudioFormat::S16BE => "S16BE".to_string(),
+        sdl3::audio::AudioFormat::S32LE => "S32LE".to_string(),
+        sdl3::audio::AudioFormat::S32BE => "S32BE".to_string(),
+        sdl3::audio::AudioFormat::F32LE => "F32LE".to_string(),
+        sdl3::audio::AudioFormat::F32BE => "F32BE".to_string(),
+        sdl3::audio::AudioFormat::UNKNOWN => "UNKNOWN".to_string(),
     }
 }

--- a/rust/src/gdext/client.rs
+++ b/rust/src/gdext/client.rs
@@ -425,19 +425,19 @@ impl GodotM8Client {
     ///
     /// If initialization fails, [struct@audio_backend] will still be [None].
     fn audio_try_init(&mut self) {
-        godot_print!("audio: initializing...");
         let Some(backend_name) = &self.audio_backend_name else {
-            godot_warn!("audio: failed to initialize - backend has not been set");
+            godot_warn!("libm8: failed to initialize audio - backend has not been set");
             return;
         };
+        godot_print!("libm8: initializing audio with backend {backend_name}...");
         if self.audio_backend.is_none() {
             self.audio_backend = match create_audio_backend(backend_name) {
                 Ok(audio_backend) => {
-                    godot_print!("audio: initialized");
+                    godot_print!("libm8: initialized");
                     Some(audio_backend)
                 }
                 Err(e) => {
-                    godot_error!("audio: failed to initialize: {}", e);
+                    godot_error!("libm8: failed to initialize: {}", e);
                     None
                 }
             };
@@ -446,12 +446,19 @@ impl GodotM8Client {
 
     #[func]
     fn audio_set_backend(&mut self, backend_name: GString) {
+        if self
+            .audio_backend_name
+            .as_ref()
+            .is_some_and(|name| name == &backend_name.to_string())
+        {
+            return;
+        }
         self.audio_stop();
         self.audio_backend_name = if backend_name.is_empty() {
-            godot_print!("audio: backend set to none");
+            godot_print!("libm8: backend set to none");
             None
         } else {
-            godot_print!("audio: backend set to '{}'", backend_name);
+            godot_print!("libm8: backend set to '{}'", backend_name);
             Some(backend_name.to_string())
         };
     }
@@ -486,8 +493,8 @@ impl GodotM8Client {
     fn audio_stop(&mut self) {
         if self.is_audio_enabled() {
             godot_print!("audio: stopping...");
-            self.audio_backend = None;
         }
+        self.audio_backend = None;
     }
 
     #[func]
@@ -509,7 +516,10 @@ impl GodotM8Client {
 
     #[func]
     fn is_audio_enabled(&mut self) -> bool {
-        self.audio_backend.is_some() && self.audio_backend.as_ref().unwrap().is_running()
+        match self.audio_backend.as_ref() {
+            Some(backend) => backend.is_running(),
+            None => false,
+        }
     }
 
     #[func]


### PR DESCRIPTION
- fixed audio not using the correct handler when changing handlers
- cpal: now uses the lowest possible buffer size for the input/output devices if the requested buffer size is not supported
- cpal: now resamples between 44.1kHz and 48kHz if there is a sample rate mismatch between the input and output devices
- cpal: fixed disabling spectrum analyzer not working